### PR TITLE
Change file params to have tempLocation instead of name

### DIFF
--- a/src/Web/Spock/Digestive.hs
+++ b/src/Web/Spock/Digestive.hs
@@ -32,5 +32,5 @@ runForm formName form =
                  applyParam f =
                      map (f . snd) . filter ((== name) . fst)
              vars <- (applyParam (TextInput)) <$> params
-             sentFiles <- (applyParam (FileInput . T.unpack . uf_name) . HM.toList) <$> files
+             sentFiles <- (applyParam (FileInput . uf_tempLocation) . HM.toList) <$> files
              return (vars ++ sentFiles)


### PR DESCRIPTION
Hi, I'm not sure if this is a misunderstanding on my part, but it seems as though spock-digestive is doing the wrong thing with file uploads. It seems like the equivalent commands in most frameworks will return the location of the file that has been uploaded while runForms here instead returns the file name. I don't see much use for that, so I'm guessing that perhaps the file upload functionality just hasn't really been used yet.

This patch changes the behaviour to the one which seems correct (or at least common), and it works in my application now.
